### PR TITLE
Switch to CF IPFS Gateway for speed improvements

### DIFF
--- a/src/app/_services/abiConfig.js
+++ b/src/app/_services/abiConfig.js
@@ -42,7 +42,7 @@ class abiConfigs {
     }
 
     getIpfsLink() {
-        return 'https://ipfs.infura.io/ipfs/';
+        return 'https://cloudflare-ipfs.com/ipfs/';
     }
 
     async contractInstanceGenerator(web3, type) {


### PR DESCRIPTION
Cloudflare just released their own IPFS gateway, and its speed is insanely fast compared with Infura. Let's switch !